### PR TITLE
Switch PRNG from xorshift7 to alea

### DIFF
--- a/src/bingo.ts
+++ b/src/bingo.ts
@@ -1,4 +1,4 @@
-import { PRNG, xorshift7 } from 'seedrandom';
+import { PRNG, alea } from 'seedrandom';
 import { free, choices } from './bingo.data';
 
 export type CellData = {
@@ -137,7 +137,7 @@ export class Bingo {
   }
 
   static init(el: HTMLElement, sp: SeedParams) {
-    const rng = xorshift7(`${sp.user.toLowerCase()} ${sp.ts}`);
+    const rng = alea(`${sp.user.toLowerCase()} ${sp.ts}\n`);
     const card = shuffle(choices.slice(), rng).slice(0, 24);
 
     const bingo = new Bingo(el, sp);


### PR DESCRIPTION
xorshift7 has a flaw in its initialization that ignores the first 7 characters of the seed (see https://github.com/davidbau/seedrandom/issues/84)

The `seedrandom` package, while heavily used, does not appear to be very rigorously tested after reviewing the source; consider switching the package in the future. For now, alea seems to respect even single character seeds and that's probably all we need.

Thanks to Twitch users inks000 for identifying the problem and hexdefined for hunting down the details